### PR TITLE
Adding MS SQL to Clever-ORM

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function( grunt ) {
                             config: 'cleverstackorm.username',
                             type: 'input',
                             message: 'Database username',
-                            default: '',
+                            default: ''
                         },
                         {
                             config: 'cleverstackorm.password',
@@ -41,7 +41,8 @@ module.exports = function( grunt ) {
                                 { name: 'mysql' },
                                 { name: 'mariadb' },
                                 { name: 'postgres' },
-                                { name: 'sqlite' }
+                                { name: 'sqlite' },
+                                { name: 'mssql' }
                             ]
                         },
                         {

--- a/bin/rebase.js
+++ b/bin/rebase.js
@@ -21,7 +21,14 @@ moduleLdr.on( 'modulesLoaded', function() {
     async.waterfall(
         [
             function createDatabase( callback ) {
-                var query = 'CREATE DATABASE ' + ( config[ 'clever-orm' ].db.options.dialect === 'mysql' ? 'IF NOT EXISTS ' : '' ) + config[ 'clever-orm' ].db.database;
+                var query;
+
+                if ( config[ 'clever-orm' ].db.options.dialect !== 'mssql' ) {
+                    query = 'CREATE DATABASE ' + ( config[ 'clever-orm' ].db.options.dialect === 'mysql' ? 'IF NOT EXISTS ' : '' ) + config[ 'clever-orm' ].db.database;
+                }
+                else {
+                    query = "IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = '" + config[ 'clever-orm' ].db.database + "') CREATE DATABASE [" + config[ 'clever-orm' ].db.database + "]";
+                }
 
                 sequelize.query( query, { raw: true } )
                     .then( function() {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "license":      "BSD-2-Clause",
     "dependencies": {
         "mysql":        "2.0.0-rc2",
+        "tedious":      "~1.9.0",  //  for ms-sql database
         "sequelize":    "~2.0.0-rc8"
     },
     "devDependencies": {


### PR DESCRIPTION
Please pull into master branch, enables users to have MS SQL database with cleverstack backend.
Required driver by sequalize is tedious (currently on version 1.9)
Corrected "Create database..." query to work for MS SQL in rebase file